### PR TITLE
feat: add side pagination arrows and hide page numbers options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Project Notes
+
+## TODO
+- Create a follow-up PR to make existing block-style `if` conditionals in the URL query params sync effect (`ContributorsGrid.tsx` lines 156-164) consistent as one-liners, matching the new compact style used for layout config params.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ Example embed:
 ></iframe>
 ```
 
+You can customize the widget by appending query parameters to the URL:
+
+| Parameter          | Description                          | Values                          | Default  |
+| ------------------ | ------------------------------------ | ------------------------------- | -------- |
+| `orgMembers`       | Show only org members                | `true`, `false`                 | `false`  |
+| `lastYear`         | Display last year's contributions    | `true`, `false`                 | `false`  |
+| `page`             | Initial page number                  | Any positive integer            | `1`      |
+| `paginationArrows` | Position of pagination arrows        | `bottom`, `side`                | `bottom` |
+| `hidePageNumbers`  | Hide the page number indicators      | `true`, `false`                 | `false`  |
+
+Example with parameters:
+
+```html
+<iframe
+  src="https://your-deployment-url.com/widget?orgMembers=true&paginationArrows=side&hidePageNumbers=true"
+  title="Contributors Spotlight"
+  width="100%"
+  height="800"
+  style="border:0;"
+  loading="lazy"
+></iframe>
+```
+
 ## Automating Contributor Data Generation
 
 This repository includes a GitHub Action to automate the generation of contributor data (see [.github/workflows/org-contributors-info.yml](.github/workflows/org-contributors-info.yml)). This action runs the `get_org_contributors_info.py` script and publishes the generated `contributors_info.json` file to the repository's GitHub Pages. The action uses the Livepeer organization as an example. To use it for your organization, enable [GitHub Pages](https://pages.github.com/) for your forked repository and update the following environment variables in the action:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,67 +210,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -334,24 +346,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.1.9':
     resolution: {integrity: sha512-uZ1HazKcyWC7RA6j+S/8aYgvxmDqwnG+gE5S9MhY7BTMj7ahXKunpKuX8/BA2M7OvINLv7LTzoobQbw928p3WA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.1.9':
     resolution: {integrity: sha512-gQIX1d3ct2RBlgbbWOrp+SHExmtmFm/HSW1Do5sSGMDyzbkYhS2sdq5LRDJWWsQu+/MqpgJHqJT6ORolKp/U1g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.1.9':
     resolution: {integrity: sha512-fJOwxAbCeq6Vo7pXZGDP6iA4+yIBGshp7ie2Evvge7S7lywyg7b/SGqcvWq/jYcmd0EbXdb7hBfdqSQwTtGTPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.1.9':
     resolution: {integrity: sha512-crfbUkAd9PVg9nGfyjSzQbz82dPvc4pb1TeP0ZaAdGzTH6OfTU9kxidpFIogw0DYIEadI7hRSvuihy2NezkaNQ==}

--- a/src/components/ContributorsGrid/ContributorsGrid.tsx
+++ b/src/components/ContributorsGrid/ContributorsGrid.tsx
@@ -164,12 +164,8 @@ export const ContributorsGrid = () => {
     }
 
     // Preserve layout configuration params
-    if (sideArrows) {
-      params.set("paginationArrows", "side");
-    }
-    if (hidePageNumbers) {
-      params.set("hidePageNumbers", "true");
-    }
+    if (sideArrows) params.set("paginationArrows", "side");
+    if (hidePageNumbers) params.set("hidePageNumbers", "true");
 
     router.replace(`?${params.toString()}`);
   }, [

--- a/src/components/ContributorsGrid/ContributorsGrid.tsx
+++ b/src/components/ContributorsGrid/ContributorsGrid.tsx
@@ -338,10 +338,10 @@ export const ContributorsGrid = () => {
             aria-label="Go to previous page"
             disabled={isPrevDisabled}
             onClick={() => handlePageChange(currentPage - 1)}
-            className={`flex-shrink-0 p-2 rounded-md transition-colors ${
+            className={`flex-shrink-0 p-2 rounded-full border border-muted-foreground/20 bg-muted/40 transition-colors ${
               isPrevDisabled
                 ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-accent cursor-pointer"
+                : "hover:bg-accent hover:border-muted-foreground/40 cursor-pointer"
             }`}
           >
             <ChevronLeft className="h-6 w-6" />
@@ -351,10 +351,10 @@ export const ContributorsGrid = () => {
             aria-label="Go to next page"
             disabled={isNextDisabled}
             onClick={() => handlePageChange(currentPage + 1)}
-            className={`flex-shrink-0 p-2 rounded-md transition-colors ${
+            className={`flex-shrink-0 p-2 rounded-full border border-muted-foreground/20 bg-muted/40 transition-colors ${
               isNextDisabled
                 ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-accent cursor-pointer"
+                : "hover:bg-accent hover:border-muted-foreground/40 cursor-pointer"
             }`}
           >
             <ChevronRight className="h-6 w-6" />

--- a/src/components/ContributorsGrid/ContributorsGrid.tsx
+++ b/src/components/ContributorsGrid/ContributorsGrid.tsx
@@ -20,6 +20,7 @@ import { ControlPanel } from "./ControlPanel";
 import { ContributorCard } from "./ContributorCard";
 import { Pagination } from "./Pagination";
 import { Contributor, VipContributor } from "@/types";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 // The number of contributors to show per page based on screen size.
 const ITEMS_PER_PAGE = {
@@ -104,6 +105,11 @@ export const ContributorsGrid = () => {
   const [itemsPerPage, setItemsPerPage] = useState(getItemsPerPage());
   const [loading, setLoading] = useState(true);
 
+  // Layout configuration from query parameters (read-only, not user-toggled)
+  const paginationArrows = searchParams.get("paginationArrows") ?? "bottom";
+  const sideArrows = paginationArrows === "side";
+  const hidePageNumbers = searchParams.get("hidePageNumbers") === "true";
+
   // Fetch contributors info from the API endpoints.
   useEffect(() => {
     const fetchContributors = async () => {
@@ -156,8 +162,24 @@ export const ContributorsGrid = () => {
     if (currentPage > 1) {
       params.set("page", currentPage.toString());
     }
+
+    // Preserve layout configuration params
+    if (sideArrows) {
+      params.set("paginationArrows", "side");
+    }
+    if (hidePageNumbers) {
+      params.set("hidePageNumbers", "true");
+    }
+
     router.replace(`?${params.toString()}`);
-  }, [excludeOrgMembers, displayLastYearContributions, currentPage, router]);
+  }, [
+    excludeOrgMembers,
+    displayLastYearContributions,
+    currentPage,
+    router,
+    sideArrows,
+    hidePageNumbers,
+  ]);
 
   // Adjust items per page based on screen size
   useEffect(() => {
@@ -210,6 +232,100 @@ export const ContributorsGrid = () => {
     startIndex + itemsPerPage
   );
 
+  const isPrevDisabled = currentPage <= 1;
+  const isNextDisabled = currentPage === totalPages;
+
+  const contributorGrid = (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 w-full items-start justify-items-start my-6 px-4">
+      {loading
+        ? Array.from({ length: itemsPerPage }).map((_, index) => (
+            <div
+              key={`skeleton-${index}`}
+              className="flex flex-col items-center w-full min-w-[125px]"
+            >
+              <Skeleton className="w-32 h-32 sm:w-28 sm:h-28 md:w-24 md:h-24 lg:w-20 lg:h-20 rounded-full" />
+              <Skeleton className="mt-3 w-24 h-4" />
+              <Skeleton className="mt-2 w-28 h-4" />
+            </div>
+          ))
+        : selectedContributors.map((contributor) => {
+            const truncatedName = truncateString(contributor.login, 14);
+            const isTruncated = truncatedName !== contributor.login;
+
+            return (
+              <div
+                key={contributor.login}
+                className="flex flex-col items-center w-full min-w-[125px]"
+              >
+                <ContributorCard
+                  key={contributor.login}
+                  contributor={contributor}
+                >
+                  <Avatar
+                    className={`w-32 h-32 sm:w-28 sm:h-28 md:w-24 md:h-24 lg:w-20 lg:h-20 border-2 ${
+                      isOrgMember(contributor, ORG_NAME) && contributor.is_vip
+                        ? "border-t-livepeer border-b-yellow-600 border-l-livepeer border-r-yellow-600"
+                        : isOrgMember(contributor, ORG_NAME)
+                        ? "border-livepeer"
+                        : contributor.is_vip
+                        ? "border-yellow-600"
+                        : ""
+                    }`}
+                  >
+                    <AvatarImage
+                      src={contributor.avatar_url}
+                      alt={contributor.login}
+                    />
+                    <AvatarFallback className="w-full h-full">
+                      {contributor.login.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                </ContributorCard>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={`https://github.com/${contributor.login}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <p
+                          className={`mt-2 text-center ${
+                            isOrgMember(contributor, ORG_NAME)
+                              ? "text-livepeer"
+                              : ""
+                          }`}
+                        >
+                          {truncatedName}
+                        </p>
+                      </a>
+                    </TooltipTrigger>
+                    {isTruncated && (
+                      <TooltipContent>{contributor.login}</TooltipContent>
+                    )}
+                  </Tooltip>
+                </TooltipProvider>
+                <a
+                  href={`https://github.com/search?q=org%3Alivepeer+author%3A${contributor.login}&type=commits`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <p className="text-sm text-gray-500">
+                    Contributions:{" "}
+                    {formatCompactNumber(
+                      displayLastYearContributions
+                        ? contributor.yearly_contributions
+                        : contributor.contributions
+                    )}
+                  </p>
+                </a>
+              </div>
+            );
+          })}
+      {/* Add placeholders to fill the empty spaces */}
+    </div>
+  );
+
   return (
     <div className="flex flex-col items-center">
       {/* Control Panel */}
@@ -219,103 +335,50 @@ export const ContributorsGrid = () => {
         setExcludeOrgMembers={setExcludeOrgMembers}
         setDisplayLastYearContributions={setDisplayLastYearContributions}
       />
-      {/* Contributor Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 w-full items-start justify-items-start my-6 px-4">
-        {loading
-          ? Array.from({ length: itemsPerPage }).map((_, index) => (
-              <div
-                key={`skeleton-${index}`}
-                className="flex flex-col items-center w-full min-w-[125px]"
-              >
-                <Skeleton className="w-32 h-32 sm:w-28 sm:h-28 md:w-24 md:h-24 lg:w-20 lg:h-20 rounded-full" />
-                <Skeleton className="mt-3 w-24 h-4" />
-                <Skeleton className="mt-2 w-28 h-4" />
-              </div>
-            ))
-          : selectedContributors.map((contributor) => {
-              const truncatedName = truncateString(contributor.login, 14);
-              const isTruncated = truncatedName !== contributor.login;
-
-              return (
-                <div
-                  key={contributor.login}
-                  className="flex flex-col items-center w-full min-w-[125px]"
-                >
-                  <ContributorCard
-                    key={contributor.login}
-                    contributor={contributor}
-                  >
-                    <Avatar
-                      className={`w-32 h-32 sm:w-28 sm:h-28 md:w-24 md:h-24 lg:w-20 lg:h-20 border-2 ${
-                        isOrgMember(contributor, ORG_NAME) && contributor.is_vip
-                          ? "border-t-livepeer border-b-yellow-600 border-l-livepeer border-r-yellow-600"
-                          : isOrgMember(contributor, ORG_NAME)
-                          ? "border-livepeer"
-                          : contributor.is_vip
-                          ? "border-yellow-600"
-                          : ""
-                      }`}
-                    >
-                      <AvatarImage
-                        src={contributor.avatar_url}
-                        alt={contributor.login}
-                      />
-                      <AvatarFallback className="w-full h-full">
-                        {contributor.login.slice(0, 2).toUpperCase()}
-                      </AvatarFallback>
-                    </Avatar>
-                  </ContributorCard>
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <a
-                          href={`https://github.com/${contributor.login}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          <p
-                            className={`mt-2 text-center ${
-                              isOrgMember(contributor, ORG_NAME)
-                                ? "text-livepeer"
-                                : ""
-                            }`}
-                          >
-                            {truncatedName}
-                          </p>
-                        </a>
-                      </TooltipTrigger>
-                      {isTruncated && (
-                        <TooltipContent>{contributor.login}</TooltipContent>
-                      )}
-                    </Tooltip>
-                  </TooltipProvider>
-                  <a
-                    href={`https://github.com/search?q=org%3Alivepeer+author%3A${contributor.login}&type=commits`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <p className="text-sm text-gray-500">
-                      Contributions:{" "}
-                      {formatCompactNumber(
-                        displayLastYearContributions
-                          ? contributor.yearly_contributions
-                          : contributor.contributions
-                      )}
-                    </p>
-                  </a>
-                </div>
-              );
-            })}
-        {/* Add placeholders to fill the empty spaces */}
-      </div>
+      {/* Contributor Grid (with optional side arrows) */}
+      {sideArrows ? (
+        <div className="flex items-center w-full">
+          <button
+            aria-label="Go to previous page"
+            disabled={isPrevDisabled}
+            onClick={() => handlePageChange(currentPage - 1)}
+            className={`flex-shrink-0 p-2 rounded-md transition-colors ${
+              isPrevDisabled
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent cursor-pointer"
+            }`}
+          >
+            <ChevronLeft className="h-6 w-6" />
+          </button>
+          <div className="flex-1 min-w-0">{contributorGrid}</div>
+          <button
+            aria-label="Go to next page"
+            disabled={isNextDisabled}
+            onClick={() => handlePageChange(currentPage + 1)}
+            className={`flex-shrink-0 p-2 rounded-md transition-colors ${
+              isNextDisabled
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-accent cursor-pointer"
+            }`}
+          >
+            <ChevronRight className="h-6 w-6" />
+          </button>
+        </div>
+      ) : (
+        contributorGrid
+      )}
       {/* Pagination widget */}
-      <div className="flex justify-center w-full">
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-        />
-      </div>
+      {!(sideArrows && hidePageNumbers) && (
+        <div className="flex justify-center w-full">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+            hideArrows={sideArrows}
+            hidePageNumbers={hidePageNumbers}
+          />
+        </div>
+      )}
       {/* Footer */}
       <Footer />
     </div>

--- a/src/components/ContributorsGrid/Pagination/Pagination.tsx
+++ b/src/components/ContributorsGrid/Pagination/Pagination.tsx
@@ -26,6 +26,10 @@ interface ContributorsPaginationProps {
   totalPages: number;
   /** Function to call when the page changes. */
   onPageChange: (page: number) => void;
+  /** Whether to hide the previous/next arrow buttons (e.g. when using side arrows). */
+  hideArrows?: boolean;
+  /** Whether to hide the page number indicators. */
+  hidePageNumbers?: boolean;
 }
 
 /**
@@ -36,6 +40,8 @@ export const Pagination = ({
   currentPage,
   totalPages,
   onPageChange,
+  hideArrows = false,
+  hidePageNumbers = false,
 }: ContributorsPaginationProps) => {
   /**
    * Renders the pagination items.
@@ -136,31 +142,39 @@ export const Pagination = ({
           <Skeleton className="w-[340px] sm:w-[460px] h-9" />
         ) : (
           <>
-            <PaginationItem>
-              <PaginationPrevious
-                href="#"
-                aria-disabled={currentPage <= 1}
-                tabIndex={currentPage <= 1 ? -1 : undefined}
-                onClick={() => onPageChange(currentPage - 1)}
-                className={`${
-                  totalPages > 4 ? "pagination-previous-mobile" : ""
-                } ${currentPage <= 1 ? "pointer-events-none opacity-50" : ""}`}
-              />
-            </PaginationItem>
-            {renderPaginationItems}
-            <PaginationItem>
-              <PaginationNext
-                href="#"
-                aria-disabled={currentPage === totalPages}
-                tabIndex={currentPage === totalPages ? -1 : undefined}
-                onClick={() => onPageChange(currentPage + 1)}
-                className={`${totalPages > 4 ? "pagination-next-mobile" : ""} ${
-                  currentPage === totalPages
-                    ? "pointer-events-none opacity-50"
-                    : ""
-                }`}
-              />
-            </PaginationItem>
+            {!hideArrows && (
+              <PaginationItem>
+                <PaginationPrevious
+                  href="#"
+                  aria-disabled={currentPage <= 1}
+                  tabIndex={currentPage <= 1 ? -1 : undefined}
+                  onClick={() => onPageChange(currentPage - 1)}
+                  className={`${
+                    totalPages > 4 ? "pagination-previous-mobile" : ""
+                  } ${
+                    currentPage <= 1 ? "pointer-events-none opacity-50" : ""
+                  }`}
+                />
+              </PaginationItem>
+            )}
+            {!hidePageNumbers && renderPaginationItems}
+            {!hideArrows && (
+              <PaginationItem>
+                <PaginationNext
+                  href="#"
+                  aria-disabled={currentPage === totalPages}
+                  tabIndex={currentPage === totalPages ? -1 : undefined}
+                  onClick={() => onPageChange(currentPage + 1)}
+                  className={`${
+                    totalPages > 4 ? "pagination-next-mobile" : ""
+                  } ${
+                    currentPage === totalPages
+                      ? "pointer-events-none opacity-50"
+                      : ""
+                  }`}
+                />
+              </PaginationItem>
+            )}
           </>
         )}
       </PaginationContent>


### PR DESCRIPTION
Add two new query parameters for better widget embedding:
- `paginationArrows=side` places prev/next arrows beside the card grid
- `hidePageNumbers=true` hides the page number indicators

These can be combined for a minimal navigation experience
(side arrows only) or used independently.