### PR TITLE
feat: add side pagination arrows and hide page numbers options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,1 @@
 # Project Notes
-
-## TODO
-- Create a follow-up PR to make existing block-style `if` conditionals in the URL query params sync effect (`ContributorsGrid.tsx` lines 156-164) consistent as one-liners, matching the new compact style used for layout config params.

--- a/src/components/ContributorsGrid/ContributorsGrid.tsx
+++ b/src/components/ContributorsGrid/ContributorsGrid.tsx
@@ -153,15 +153,9 @@ export const ContributorsGrid = () => {
   // Update the URL query params when the state changes.
   useEffect(() => {
     const params = new URLSearchParams();
-    if (excludeOrgMembers) {
-      params.set("orgMembers", "false");
-    }
-    if (displayLastYearContributions) {
-      params.set("lastYear", "true");
-    }
-    if (currentPage > 1) {
-      params.set("page", currentPage.toString());
-    }
+    if (excludeOrgMembers) params.set("orgMembers", "false");
+    if (displayLastYearContributions) params.set("lastYear", "true");
+    if (currentPage > 1) params.set("page", currentPage.toString());
 
     // Preserve layout configuration params
     if (sideArrows) params.set("paginationArrows", "side");


### PR DESCRIPTION
Add two new query parameters for better widget embedding:
- `paginationArrows=side` places prev/next arrows beside the card grid
- `hidePageNumbers=true` hides the page number indicators

These can be combined for a minimal navigation experience
(side arrows only) or used independently.

https://claude.ai/code/session_01TuFaZSo2RTtkhyZgGkrZdL