### PR TITLE
feat/improve inline widget

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >

--- a/src/components/ContributorsGrid/ContributorsGrid.tsx
+++ b/src/components/ContributorsGrid/ContributorsGrid.tsx
@@ -132,18 +132,14 @@ export const ContributorsGrid = () => {
   );
   const [displayLastYearContributions, setDisplayLastYearContributions] =
     useLocalStorage("lastYear", false);
+  // Use unclamped cols/rows for initial state so server and client match.
+  // CSS responsive classes handle mobile hiding; useLayoutEffect corrects after hydration.
   const [itemsPerPage, setItemsPerPage] = useState(() => {
-    if (cols || rows) {
-      const responsiveMax = getResponsiveCols();
-      return Math.min(cols ?? responsiveMax, responsiveMax) * (rows ?? 1);
-    }
+    if (cols || rows) return (cols ?? 1) * (rows ?? 1);
     return getItemsPerPage();
   });
   const [effectiveCols, setEffectiveCols] = useState<number | null>(() => {
-    if (cols || rows) {
-      const responsiveMax = getResponsiveCols();
-      return Math.min(cols ?? responsiveMax, responsiveMax);
-    }
+    if (cols || rows) return cols ?? 1;
     return null;
   });
   const [loading, setLoading] = useState(true);

--- a/src/components/ContributorsGrid/Pagination/Pagination.tsx
+++ b/src/components/ContributorsGrid/Pagination/Pagination.tsx
@@ -139,7 +139,7 @@ export const Pagination = ({
     <UIPagination>
       <PaginationContent>
         {totalPages < 1 ? (
-          <Skeleton className="w-[340px] sm:w-[460px] h-9" />
+          <Skeleton className={hideArrows ? "w-[276px] h-9" : "w-[340px] sm:w-[460px] h-9"} />
         ) : (
           <>
             {!hideArrows && (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -34,7 +34,7 @@ export const Header = () => {
   const getLogoContent = () => {
     if (!mounted) {
       return (
-        <div className="w-[30px] h-[36px] mr-4 flex items-center justify-center">
+        <div className="w-[30px] h-[30px] mr-4 flex items-center justify-center">
           <Skeleton className="w-full h-full" />
         </div>
       );

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -98,3 +98,18 @@ export const formatCompactNumber = (num: number): string => {
 export const truncateString = (str: string, maxLength: number): string => {
   return str.length > maxLength ? `${str.slice(0, maxLength)}...` : str;
 };
+
+/**
+ * Shuffles an array using the Fisher-Yates algorithm.
+ * Returns a new array without mutating the original.
+ * @param array - The array to shuffle.
+ * @returns A new shuffled array.
+ */
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+};


### PR DESCRIPTION
Add three new query parameters for widget embedding: `randomize` shuffles contributor order, `cols`/`columns` and `rows` control grid dimensions with responsive clamping. Includes skeleton loading states that match the final layout across all screen sizes using CSS-based responsive grids pre-hydration.
